### PR TITLE
Add content-type to fetch request

### DIFF
--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -66,6 +66,10 @@ export default class HttpProvider extends Provider {
 
     const body = await fetch(this.url, {
       method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
       body: json,
       cache: 'no-cache',
       ...this.params


### PR DESCRIPTION
JSON_RPC requires the content-type to be application/json so we set the header on the fetch request