### PR TITLE
Replace tokens balances call with per address calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: yarn compile
 
       - name: Test
-        run: yarn test
+        run: yarn test --coverage
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v1

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   roots: ['src/', 'tests/'],
   clearMocks: true,
-  collectCoverage: true,
   collectCoverageFrom: ['**/*.ts?(x)', '!**/*.d.ts', '!src/contracts/**/*', '!src/vendor/**/*'],
   transform: {
     '^.+\\.[t|j]sx?$': 'babel-jest'


### PR DESCRIPTION
This is a (temporary) solution for an issue that occurs when fetching many tokens and addresses at once, resulting in node calls that are too large.