### PR TITLE
Fix gas issues when querying certain proxy contracts

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,8 +1,9 @@
 {
   "extends": "solhint:recommended",
   "rules": {
+    "bracket-align": false,
     "compiler-version": ["error", "0.8.3"],
-    "indent": ["error", 2],
+    "indent": false,
     "modifier-name-mixedcase": "error",
     "func-param-name-mixedcase": "error",
     "func-visibility": ["error", { "ignoreConstructors": true }],

--- a/.solhint.json
+++ b/.solhint.json
@@ -1,7 +1,7 @@
 {
   "extends": "solhint:recommended",
   "rules": {
-    "compiler-version": ["error", "^0.7.0"],
+    "compiler-version": ["error", "0.8.3"],
     "indent": ["error", 2],
     "modifier-name-mixedcase": "error",
     "func-param-name-mixedcase": "error",

--- a/contracts/BalanceScanner.sol
+++ b/contracts/BalanceScanner.sol
@@ -88,6 +88,7 @@ contract BalanceScanner {
       (bool success, bytes memory data) = token.staticcall{ gas: 20000 }(
         abi.encodeWithSignature("balanceOf(address)", owner)
       );
+
       if (success) {
         (balance) = abi.decode(data, (uint256));
       }

--- a/contracts/BalanceScanner.sol
+++ b/contracts/BalanceScanner.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity 0.8.3;
-pragma experimental ABIEncoderV2;
 
 /**
  * @title An Ether or token balance scanner
@@ -79,7 +78,8 @@ contract BalanceScanner {
     * @param owner The address of the token owner
     * @param token The address of the ERC-20 token contract
     * @return balance The token balance, or zero if the address is not a contract, or does not implement the `balanceOf`
-      function
+      function. This will also be zero if the target contract tries to modify the state, e.g., when using certain proxy
+      contracts.
   */
   function tokenBalance(address owner, address token) private view returns (uint256 balance) {
     uint256 size = codeSize(token);

--- a/contracts/BalanceScanner.sol
+++ b/contracts/BalanceScanner.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.7.2;
+pragma solidity 0.8.3;
 pragma experimental ABIEncoderV2;
 
 /**
@@ -85,7 +85,9 @@ contract BalanceScanner {
     uint256 size = codeSize(token);
 
     if (size > 0) {
-      (bool success, bytes memory data) = token.staticcall(abi.encodeWithSignature("balanceOf(address)", owner));
+      (bool success, bytes memory data) = token.staticcall{ gas: 20000 }(
+        abi.encodeWithSignature("balanceOf(address)", owner)
+      );
       if (success) {
         (balance) = abi.decode(data, (uint256));
       }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,7 +7,7 @@ import 'hardhat-typechain';
 const config: HardhatUserConfig = {
   defaultNetwork: 'hardhat',
   solidity: {
-    version: '0.7.2',
+    version: '0.8.3',
     settings: {
       optimizer: {
         enabled: true,

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-solhint": "^2.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "@openzeppelin/contracts": "^3.3.0",
+    "@openzeppelin/contracts": "^4.0.0",
     "@typechain/ethers-v5": "^5.0.0",
     "@types/ethereumjs-abi": "^0.6.3",
     "@types/jest": "^26.0.10",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prettier": "^2.1.2",
     "prettier-plugin-solidity": "^1.0.0-alpha.58",
     "rimraf": "^3.0.2",
-    "solhint": "^3.3.2",
+    "solhint": "^3.3.4",
     "ts-node": "^9.0.0",
     "typechain": "^4.0.1",
     "typescript": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,10 +2165,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.3.0.tgz#ffdb693c5c349fc33bba420248dd3ac0a2d7c408"
-  integrity sha512-AemZEsQYtUp1WRkcmZm1div5ORfTpLquLaziCIrSagjxyKdmObxuaY1yjQ5SHFMctR8rLwp706NXTbiIRJg7pw==
+"@openzeppelin/contracts@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.0.0.tgz#54d1de30911635020c383cb73b160b698e7ae179"
+  integrity sha512-UcIJl/vUVjTr3H1yYXZi7Sr2PlXzBEHVUJKOUlVyzyy0FI8oQCCy0Wx+BuK/fojdnmLeMvUk4KUvhKUybP+C7Q==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2299,15 +2299,15 @@
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.11.0.tgz#28bc1972e1620f7b388b485bca76a78ac2cb5c59"
   integrity sha512-IaC4IaW8uoOB8lmEkw6c19y1vJBK/+7SzAbGQ+LmBYRPXSLNB+UgpORvmcAJEXhB04kWKyz/Os1U8onqm6U/+w==
 
+"@solidity-parser/parser@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.12.0.tgz#18a0fb2a9d2484b23176f63b16093c64794fc323"
+  integrity sha512-DT3f/Aa4tQysZwUsuqBwvr8YRJzKkvPUKV/9o2/o5EVw3xqlbzmtx4O60lTUcZdCawL+N8bBLNUyOGpHjGlJVQ==
+
 "@solidity-parser/parser@^0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.8.1.tgz#1b606578af86b9ad10755409804a6ba83f9ce8a4"
   integrity sha512-DF7H6T8I4lo2IZOE2NZwt3631T8j1gjpQLjmvY2xBNK50c4ltslR4XPKwT6RkeSd4+xCAK0GHC/k7sbRDBE4Yw==
-
-"@solidity-parser/parser@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.8.2.tgz#a6a5e93ac8dca6884a99a532f133beba59b87b69"
-  integrity sha512-8LySx3qrNXPgB5JiULfG10O3V7QTxI/TLzSw5hFQhXWSkVxZBAv4rZQ0sYgLEbc8g3L2lmnujj1hKul38Eu5NQ==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -11473,12 +11473,12 @@ solhint@^2.0.0:
   optionalDependencies:
     prettier "^1.14.3"
 
-solhint@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.3.2.tgz#ebd7270bb50fd378b427d7a6fc9f2a7fd00216c0"
-  integrity sha512-8tHCkIAk1axLLG6Qu2WIH3GgNABonj9eAWejJbov3o3ujkZQRNHeHU1cC4/Dmjsh3Om7UzFFeADUHu2i7ZJeiw==
+solhint@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.3.4.tgz#81770c60eeb027e6e447cb91ed599baf5e888e09"
+  integrity sha512-AEyjshF/PC6kox1c1l79Pji+DK9WVuk5u2WEh6bBKt188gWa63NBOAgYg0fBRr5CTUmsuGc1sGH7dgUVs83mKw==
   dependencies:
-    "@solidity-parser/parser" "^0.8.2"
+    "@solidity-parser/parser" "^0.12.0"
     ajv "^6.6.1"
     antlr4 "4.7.1"
     ast-parents "0.0.1"


### PR DESCRIPTION
This fixes an issue when querying certain (non-ERC-20-compliant) proxy contracts. `eth-scan` will return a balance of 0 for these contracts.