### PR TITLE
fix performance by remove unnecessary O(n^2) and O(n^3) calls

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -16,14 +16,12 @@ const isResult = (result: unknown): result is Result => {
  * @return {BalanceMap}
  */
 export const toBalanceMap = (addresses: string[], results: Array<bigint | Result>): BalanceMap => {
-  return results.reduce<BalanceMap>((current, next, index) => {
+  const m: BalanceMap = {};
+  for (const [index, next] of results.entries()) {
     const value = isResult(next) ? toNumber(next[1].slice(0, 32)) : next;
-
-    return {
-      ...current,
-      [addresses[index]]: value
-    };
-  }, {});
+    m[addresses[index]] = value;
+  }
+  return m;
 };
 
 /**
@@ -38,12 +36,11 @@ export const toNestedBalanceMap = (
   tokenAddresses: string[],
   results: Array<Array<bigint | Result>>
 ): BalanceMap<BalanceMap> => {
-  return results.reduce<BalanceMap<BalanceMap>>((current, next, index) => {
-    return {
-      ...current,
-      [addresses[index]]: toBalanceMap(tokenAddresses, next)
-    };
-  }, {});
+  const m: BalanceMap<BalanceMap> = {};
+  for (const [index, next] of results.entries()) {
+    m[addresses[index]] = toBalanceMap(tokenAddresses, next);
+  }
+  return m;
 };
 
 /**


### PR DESCRIPTION
tobalancemap has a huge perf issue that causes continuous almost 100% cpu use if you scan a few thousand addresses. the cause is a reduce call that creates huge amounts of objects because of a clever reduce that makes it O(n^2) instead of a simple loop.  this fixes that.

profiler screenshot before: 
![image](https://github.com/MyCryptoHQ/eth-scan/assets/2303841/3459eb5f-47be-4c5b-af95-c7955507cf30)
